### PR TITLE
CI fix

### DIFF
--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -37,13 +37,13 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7.3 # Check https://pages.github.com/versions/ for the current Ruby version used by gh pages.
+          ruby-version: 2.7.4 # Check https://pages.github.com/versions/ for the current Ruby version used by gh pages.
 
       # Install dependencies required to run jekyll build
       - name: Install gh-pages rubygem via bundler
         run: |
-          # Update gem and bundler
-          gem update --system --no-document
+          # Update gem and bundler - disabled due to gem install errors on CI
+          # gem update --system --no-document
           gem update bundler --no-document
           # Set the bundle directory
           bundle config set path vendor/bundle

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
   workflow_dispatch:
 
 # Set permissions on the github.token for gh-pages use

--- a/.github/workflows/mirror.yaml
+++ b/.github/workflows/mirror.yaml
@@ -30,7 +30,7 @@ jobs:
     steps:
       # Clone the repository and checkout into the relevant branch
       - name: Checkout RSE-Sheffield/RSE-Sheffield.github.io
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: RSE-Sheffield/RSE-Sheffield.github.io
 
@@ -57,7 +57,7 @@ jobs:
 
       # Save HTML for later
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: _site/
 
@@ -73,4 +73,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Since the mirror was originally created, Ruby's packaging system has broken so the base gem update cannot be ran. This has been fixed in the rse-sheffield.github.io repo independntly. 

This PR should fix that problem, allowing the mirror to be rebuilt now that DNS is setup correctly and verified.